### PR TITLE
Add option to disable cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Url to piwik.php, default is `matomoUrl + 'piwik.php'`
 
 Url to piwik.js, default is `matomoUrl + 'piwik.js'`
 
+### `cookies`
+
+If false, Matomo will be configured to not create a tracking cookie  
+Default: `(unset)`
+
 ### Setting configuration at runtime
 You can push any additional tracking info to `_paq` at runtime by adding a matomo 
 object `route.meta.matomo` in the middleware or to the selected pages. An object

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function nuxtMatomo (options) {
   config_js += "window['_paq'].push(['setTrackerUrl', '" + (options.trackerUrl || (options.matomoUrl || options.piwikUrl)+'piwik.php') + "']);"
   config_js += "window['_paq'].push(['setSiteId', '" + options.siteId + "']);"
 
+  if (options.cookies === false) {
+    config_js += "window['_paq'].push(['disableCookies']);"
+  }
+
   if (typeof(this.options.head.__dangerouslyDisableSanitizersByTagID) === 'undefined') {
     this.options.head.__dangerouslyDisableSanitizersByTagID = {}
   }


### PR DESCRIPTION
Thanks for the module!  

Matomo has a feature that can disable cookies (it doesn't set them, or if one exists it ignores them), but `nuxt-matomo` users can't turn it on through the options object. This PR solves this issue.  

In the long run, it may be a good idea to just run through the settings object and generate a list of `_paq.push(["whatever"])` strings, so that any option (even ones that don't exist yet) may be set. :+1: 